### PR TITLE
fix project name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-ci-cd-testing-practice",
+  "name": "react-ci-cd-practice",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-ci-cd-testing-practice",
+      "name": "react-ci-cd-practice",
       "version": "0.1.0",
       "dependencies": {
         "@types/node": "^24.0.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-ci-cd-testing-practice",
+  "name": "react-ci-cd-practice",
   "version": "0.1.0",
-  "homepage": "https://flyjeray.github.io/react-ci-cd-testing-practice",
+  "homepage": "https://flyjeray.github.io/react-ci-cd-practice",
   "private": true,
   "dependencies": {
     "@types/node": "^24.0.15",


### PR DESCRIPTION
There was an issue, caused by renaming GitHub repository name, that starts conflicts with deployment URL of GitHub Pages. This fix should make it work